### PR TITLE
Fixes BetterTTS.plugin.js 's TTS Volume control functionality

### DIFF
--- a/Plugins/BetterTTS/BetterTTS.plugin.js
+++ b/Plugins/BetterTTS/BetterTTS.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name BetterTTS
  * @description A plugin that allows you to play a custom TTS when a message is received.
- * @version 2.7.0
+ * @version 2.7.1
  * @author nicola02nb
  * @invite hFuY8DfDGK
  * @authorLink https://github.com/nicola02nb
@@ -61,7 +61,7 @@ const config = {
             { type: "switch", id: "blockMutedChannels", name: "Block Muted Channels", note: "Blocks muteds channels from TTS.", value: true },
             { type: "switch", id: "blockMutedGuilds", name: "Block Muted Guilds", note: "Blocks muteds server/guilds from TTS.", value: false },
         ]},
-        { type: "slider", id: "ttsVolume", name: "TTS Volume", note: "Changes the volume of the TTS.", step: 1, value: 100, min: 0, max: 100, units: "x", markers: [0, 25, 50, 75, 100], inline: false },
+        { type: "slider", id: "ttsVolume", name: "TTS Volume", note: "Changes the volume of the TTS.", step: 0.1, value: 100, min: 0, max: 100, units: "%", markers: [0, 25, 50, 75, 100], inline: false },
         { type: "slider", id: "ttsSpeechRate", name: "TTS Speech Rate", note: "Changes the speed of the TTS.", step: 0.05, value: 1, min: 0.1, max: 2, units: "x", markers: [0.1, 1, 1.25, 1.5, 1.75, 2], inline: false },
         { type: "number", id: "ttsDelayBetweenMessages", name: "Delay Between messages (ms)", note: "Only works for Syncronous messages.", value: 1000 },
         { type: "keybind", id: "ttsToggle", name: "Toggle TTS", note: "Shortcut to toggle the TTS.", value: [] },
@@ -250,7 +250,7 @@ module.exports = class BetterTTS {
             this.settings.ttsVoice,
             this.settings.ttsSpeechRate,
             this.settings.ttsDelayBetweenMessages,
-            this.settings.ttsVolume);
+            this.settings.ttsVolume/100);
 
         document.addEventListener("keydown", this.handleKeyDown);
         DiscordModules.subscribe("RELATIONSHIP_ADD", this.handleUpdateRelations);
@@ -589,6 +589,10 @@ module.exports = class BetterTTS {
     }
 };
 
+function clamp(number, min, max) {
+    return Math.max(min, Math.min(number, max));
+  }
+
 const delay = ms => new Promise(res => setTimeout(res, ms));
 
 class AudioPlayer {
@@ -634,7 +638,7 @@ class AudioPlayer {
     updateVolume(volume) {
         this.volume = volume;
         if (this.audio)
-            this.audio.volume = volume;
+            this.audio.volume = clamp(volume, 0, 1);
     }
 
     updateDelay(delay) {
@@ -661,7 +665,7 @@ class AudioPlayer {
             }
             if (this.audio) {
                 this.audio.playbackRate = this.rate;
-                this.audio.volume = this.volume / 100;
+                this.audio.volume = clamp(this.volume, 0, 1);
                 this.audio.addEventListener('ended', async () => {
                     await delay(this.delay);
                     if (this.messagesToPlay.length === 0) {


### PR DESCRIPTION
Fixed the volume being divided by 1000% instead of 100% when being changed via the volume slider. (It looks as though you had a bandaid in place for the volume being wrong on plugin load, however that was making the slider's volume changes be doubled until the client was restarted.) Just had to remove the div/100 from setting `this.audio.volume` & moved the div/100 to config param load instead.


Changed the volume steps to 0.1, as 1% adjustments was a bit too tight, at least with my headphones - I needed more granular adjustment.

Also added a sanity check to both `this.audio.volume = volume`'s to ensure that they're always passed a valid value / don't crash the plugin if someone messes with the config file & sets the volume to a number > 100.